### PR TITLE
changed locationmerge so they retain orig. order

### DIFF
--- a/txtmerge.py
+++ b/txtmerge.py
@@ -13,7 +13,7 @@ oname = str(sys.argv[2])
 
 ofile = io.open(oname, 'w', encoding='utf-16', newline='\r\n')
 
-for iname in os.listdir( idir ):
+for iname in sorted(os.listdir( idir )):
     ifile = io.open(os.path.join(idir,iname), 'rt', encoding='utf-8')
     text = ifile.read()
     ofile.write(text)


### PR DESCRIPTION
I suddenly had problems with the merge-script.
When it merged the locations, on my machine, it would place the start location at random, not at the beginning of the file. 
That resulted in breaking the game(!?).
I googled once and just putting os.listdir() into a sorted() seems to fix the problem.